### PR TITLE
Sketch for S/Kademlia Connectivity

### DIFF
--- a/dht/KNode.go
+++ b/dht/KNode.go
@@ -1,0 +1,47 @@
+/*
+File Name:  KNode.go
+Copyright:  2021 Peernet Foundation s.r.o.
+Author:     Wesley Coakley
+
+KNodes ("Kademlia Nodes") are remote nodes on the S/Kademlia network. Each node
+is assigned a varying level of trust based on its behavior; good behavior is
+rewarded and bad behavior is punished
+*/
+
+package dht
+
+import (
+	"net"
+	"github.com/btcsuite/btcd/btcec"
+)
+
+type NodeID btcec.PublicKey
+
+// Some remote node on the network
+type KNode struct {
+	ID *NodeID // Unique network ID
+	Addr *net.UDPAddr // Dial()-able address
+
+	// Statistics
+	StatsPacketSent int // Count of packets sent
+	StatsPacketReceived int // Count of packets received
+}
+
+// Some subset of the total network
+type KNodeList []KNode
+
+// Define a node's level of trust
+type KNodeIdentity struct {
+	Pubkey *btcec.PublicKey // Distinguish public key from node ID for clarity
+	Trust int // 0 ~ 4
+}
+
+// Equivalent to GPG trust levels for node operators
+const (
+	TrustUnsure = iota
+	TrustNever
+	TrustMarginal
+	TrustFull
+	TrustUltimate
+)
+

--- a/dht/LocalNode.go
+++ b/dht/LocalNode.go
@@ -1,0 +1,170 @@
+/*
+File Name:  LocalNode.go
+Copyright:  2021 Peernet Foundation s.r.o.
+Author:     Wesley Coakley
+
+Represent the local client as an operator on the S/Kademlia network
+*/
+
+package dht
+
+import (
+	"net"
+	"time"
+
+	"github.com/PeerNetOfficial/core"
+	"github.com/btcsuite/btcd/btcec"
+)
+
+// Period to wait for UDP packet retransmission
+// ... the Conversation mechanics should probably be abstracted some more and
+// lumped in to PeerNet core but for now we handle this in the Kademlia
+// implementation
+const DEFAULT_RETRANSMIT_MS = 2000
+
+// The local client as a participant on the Kademlia network
+type LocalNode struct {
+	// Network connectivity
+	Addr *net.UDPAddr // Listening UDP address (needs abstraction)
+	Tx []*Conversation // Ongoing *outbound* conversations
+	Rx []*Conversation // Ongoing *inbound* conversations
+
+	// Self-Identity
+	ID *NodeID // Own public key
+	Keys Keyring // Known node operators on the network
+	Secretkey *btcec.PrivateKey // Own private key
+}
+
+// Keyring helps create a web of trust on the network
+type Keyring map[NodeID]KNodeIdentity
+
+// A number of transactions between local client and remote node
+type Conversation struct {
+	Myself *LocalNode // This end of the socket
+	Partner *KNode // The other end of the socket
+	Conn *net.UDPConn // Transmission layer itself
+	Retransmit *time.Timer // Retransmit on expiration
+
+	RetryCount int // Number of retries
+	MsgCount int // # of messages sent / received
+
+	Inbox core.PacketRaw
+	Outbox core.PacketRaw
+
+	// IsOutbound bool // Did we initiate this conversation?
+}
+
+// Create a new keyring with only the client's own public key on it
+//
+// This initial key is granted an immediate level of TrustUltimate
+// and should be the only key granted this privilige
+func (ln *LocalNode) InitializeKeyring() {
+	ln.Keys = make(Keyring)
+	ln.AddKeyToRing(ln.ID, TrustUltimate)
+}
+
+// Add a remote node to the local client's keyring at a given trust level
+func (ln *LocalNode) AddKeyToRing(id *NodeID, trust int) {
+	pubKey := (*btcec.PublicKey)(id)
+
+	ln.Keys[*id] = KNodeIdentity{
+		Pubkey: pubKey,
+		Trust: TrustUltimate,
+	}
+}
+
+// Set up a conversation between the local client and a remote Kademlia node
+//
+// This helps to manage things like retransmission, and gives a convenient place
+// to manage the exchange of large amounts of routing data, e.g. over multiple
+// datagrams
+func (ln *LocalNode) SetUpConversation(partner *KNode) *Conversation {
+	ret := &Conversation{
+		Myself: ln,
+		Partner: partner,
+	}
+
+	// Set up a timer to retransmit after DEFAULT_RETRANSMIT_MS seconds without
+	// seeing an ACK from the conversation partner
+	ret.Retransmit = time.AfterFunc(
+		DEFAULT_RETRANSMIT_MS * time.Millisecond,
+		ret.RetransmitLast,
+	)
+
+	return ret
+}
+
+// Create the network socket between two nodes in a conversation
+//
+// This is only a stub for now; it should be generalized to use the
+// connections we have in PeerNet core
+func (convo Conversation) SetUpConn() error {
+	conn, err := net.DialUDP("udp", nil, convo.Partner.Addr)
+
+	if err != nil { return err }
+
+	convo.Conn = conn
+	return nil
+}
+
+// Convert the local client into a "remote" Kademlia node representation
+//
+// Really only used with test functions which do not connect to the network
+// but need to "simulate" a remote connection
+func (ln LocalNode) AsKNode() *KNode {
+	return &KNode{
+		ID: ln.ID,
+		Addr: ln.Addr,
+	}
+}
+
+// Resend our most recent packet (likely the packet was lost)
+//
+// This should only be called by the retransmission timer. I realize this is an
+// inefficient algorithm for retransmission, we could possibly implement
+// something like TCP Reno but over an unreliable channel like UDP
+// ... a problem for later :)
+func (convo Conversation) RetransmitLast() {
+	convo.RetryCount = convo.RetryCount + 1
+	convo.SendOutbox()
+	convo.Retransmit.Reset(DEFAULT_RETRANSMIT_MS * time.Millisecond)
+}
+
+// Encrypt a constructed packet using the relevant keys in a Conversation
+func (convo Conversation) EncryptOutgoing(packet *core.PacketRaw) ([]byte, error) {
+	myPrivkey := convo.Myself.Secretkey
+	theirPubkey := convo.Myself.Keys[*convo.Partner.ID].Pubkey
+
+	raw, err := core.PacketEncrypt(myPrivkey, theirPubkey, packet)
+
+	return raw, err
+}
+
+// Decrypt a packet using the relevant keys in a Conversation
+func (convo Conversation) DecryptIncoming(raw []byte) (*core.PacketRaw, error) {
+	theirPubkey := convo.Myself.Keys[*convo.Partner.ID].Pubkey
+
+	decryptedPacket, _, err := core.PacketDecrypt(raw, theirPubkey)
+
+	return decryptedPacket, err
+}
+
+// Sends a message pending transmission in the Outbox; this will not remove the
+// message from the Outbox, however, that should be done on confirmation /
+// receipt of deliver from the remote node
+func (convo Conversation) SendOutbox() error {
+	raw, err := convo.EncryptOutgoing(&convo.Outbox)
+
+	_, err = convo.Conn.Write(raw)
+	if err != nil { return err }
+
+	// if size < ...
+	// TODO Actually send the packet along the communication channel
+
+	// Sent packet data
+	convo.MsgCount = convo.MsgCount + 1
+	convo.Partner.StatsPacketSent = convo.Partner.StatsPacketSent + 1
+
+	return nil
+}
+

--- a/dht/LocalNode_test.go
+++ b/dht/LocalNode_test.go
@@ -1,0 +1,94 @@
+/*
+File Name:  LocalNode_test.go
+Copyright:  2021 Peernet Foundation s.r.o.
+Author:     Wesley Coakley
+*/
+
+package dht
+
+import (
+	"net"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/PeerNetOfficial/core"
+)
+
+// A string with weird characters we'll use as payload to test
+// encryption, decryption, and transmission
+const testPayload = "TEST PASS (≧◡≦)"
+
+// Example hex-encoded btcec private key
+const testKeystr = "22a47fa09a223f2aa079edf85a7c2d4f8720ee63e502ee2869afab7" +
+	"de234b80c"
+
+// Emulate a local node using the above const expressions
+func LocalNodeForTesting() *LocalNode {
+	privKey, pubKey := FromKeystr(testKeystr)
+	id := (*NodeID)(pubKey)
+
+	dut := &LocalNode{
+		ID: id,
+		Secretkey: privKey,
+		Addr: &net.UDPAddr{},
+	}
+
+	dut.InitializeKeyring()
+
+	return dut
+}
+
+// Decode hex-encoded key string into its individual components
+func FromKeystr(key string) (*btcec.PrivateKey, *btcec.PublicKey) {
+	pkBytes, err := hex.DecodeString(key)
+	if err != nil {
+		fmt.Println(err)
+		return nil, nil
+	}
+	privKey, pubKey := btcec.PrivKeyFromBytes(btcec.S256(), pkBytes)
+	return privKey, pubKey
+}
+
+// Stub a conversation between a local client and "remote" node for testing
+// functionality
+func DummyConversation() (*Conversation) {
+	dut := LocalNodeForTesting()
+	dummyKNode := dut.AsKNode()
+
+	return dut.SetUpConversation(dummyKNode)
+}
+
+// Test ability to encrypt / decrypt packets in a Conversation between two nodes
+func TestMessageEncryption(t *testing.T) {
+	convo := DummyConversation()
+
+	// Construct a packet to test encryption
+	testPacket := &core.PacketRaw{
+		Protocol: 0,
+		Command: 0,
+		Payload: []byte(testPayload),
+	}
+
+	// Encrypt the "egressing" packet
+	encData, err := convo.EncryptOutgoing(testPacket)
+	if err != nil {
+		t.Fatalf("`convo.EncryptOutgoing`: %v", err)
+	}
+
+	// Pretend we received this data from a remote node :)
+
+	// Decrypt the "ingressing" packet
+	decPacket, err := convo.DecryptIncoming(encData)
+	if err != nil {
+		t.Fatalf("`convo.DecryptIncoming`: %v", err)
+	}
+
+	// Test that the "sent" packet is the same as the "received" packet
+	if !(decPacket.Protocol == testPacket.Protocol &&
+		decPacket.Command == testPacket.Command &&
+		string(decPacket.Payload) == testPayload) {
+		t.Fatalf("Decrypted packet did not match input packet")
+	}
+}

--- a/dht/README.md
+++ b/dht/README.md
@@ -1,0 +1,13 @@
+# PeerNet S/Kademlia Implementation
+
+This sub-package allows clients on PeerNet to organize into a Kademlia network.
+Nodes on the network interact by exchanging signed and encrypted packets, which
+themselves convey routing information among peers, as well as requests for
+resources (like files) and metadata about those resources.
+
+## DHT vs File Transfer
+
+These files do not provide the mechanisms for transferring heavy files between
+peers directly. Peers are instead organized into a coherent and highly resiliant
+P2P network which *facilitates the exchange of* direct connection details for
+use in file-transfers.


### PR DESCRIPTION
Establish idioms for Kadmlia "conversations" between DHT nodes. This sub-package will form the basis of Kademlia organization among nodes on the network.

This sub-package will not facilitate file transfers, only the exchange of DHT entries and routing information. Still relies on PeerNet "core" for connections and packet encryption.

```
cd dht
go test -v
```

... writing this on a Linux machine but aiming to make this platform-agnostic, lmk if any weird issues arise because of this. Also wasn't sure about file headers so I just copied and modified some existing ones from files in the core folder